### PR TITLE
Create subsections 'My Groups' and 'Other Groups' in Groups page

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Contributors
 
-![]({-ActivityLocation-})
+![](https://raw.githubusercontent.com/CMU-313/spring24-nodebb-caffiends/activity-resources/image.svg)
 
 
 # ![NodeBB](public/images/sm-card.png)

--- a/src/controllers/groups.js
+++ b/src/controllers/groups.js
@@ -13,6 +13,22 @@ const privileges = require('../privileges');
 const groupsController = module.exports;
 
 groupsController.list = async function (req, res) {
+    // const userData = await accountHelpers.getUserDataByUserSlug(req.params.userslug, req.uid, req.query);
+    // if (!userData) {
+    //     return next();
+    // }
+    // let groupsData = await groups.getUserGroups([userData.uid]);
+    // groupsData = groupsData[0];
+    // const groupNames = groupsData.filter(Boolean).map(group => group.name);
+    // const members = await groups.getMemberUsers(groupNames, 0, 3);
+    // groupsData.forEach((group, index) => {
+    //     group.members = members[index];
+    // });
+    // userData.groups = groupsData;
+    // userData.title = `[[pages:account/groups, ${userData.username}]]`;
+    // userData.breadcrumbs = helpers.buildBreadcrumbs([{ text: userData.username, url: `/user/${userData.userslug}` }, { text: '[[global:header.groups]]' }]);
+    // res.render('account/groups', userData);
+
     const sort = req.query.sort || 'alpha';
 
     const [groupData, allowGroupCreation] = await Promise.all([

--- a/themes/nodebb-theme-persona/templates/account/groups.tpl
+++ b/themes/nodebb-theme-persona/templates/account/groups.tpl
@@ -3,9 +3,7 @@
 
     <div class="row">
         <h1>[[pages:{template.name}, {username}]]</h1>
-        
-        <h1>pages:{template.name}</h1>
-        <h1>testing</h1>
+    
         <div class="groups list">
             <div component="groups/container" id="groups-list" class="row">
                 <!-- IF !groups.length -->

--- a/themes/nodebb-theme-persona/templates/account/groups.tpl
+++ b/themes/nodebb-theme-persona/templates/account/groups.tpl
@@ -4,6 +4,8 @@
     <div class="row">
         <h1>[[pages:{template.name}, {username}]]</h1>
         
+        <h1>pages:{template.name}</h1>
+        <h1>testing</h1>
         <div class="groups list">
             <div component="groups/container" id="groups-list" class="row">
                 <!-- IF !groups.length -->

--- a/themes/nodebb-theme-persona/templates/groups/list.tpl
+++ b/themes/nodebb-theme-persona/templates/groups/list.tpl
@@ -32,9 +32,28 @@
 
     <hr />
 
+    <h3>My Groups</h3>
+    
+    <h1>TESTING: [[pages:{template.name}, {username}]]</h1>
     <div component="groups/container" class="row" id="groups-list" data-nextstart={nextStart}>
         <!-- IF groups.length -->
-        <!-- IMPORT partials/groups/list.tpl -->
+            <!-- IMPORT partials/groups/mylist.tpl -->
+        <!-- ELSE -->
+        <div class="col-xs-12">
+            <div class="alert alert-warning">
+            [[groups:no_groups_found]]
+            </div>
+        </div>
+        <!-- ENDIF groups.length -->
+    </div>
+
+    <hr />
+
+    <h3>Other Groups</h3>
+
+    <div component="groups/container" class="row" id="groups-list" data-nextstart={nextStart}>
+        <!-- IF groups.length -->
+            <!-- IMPORT partials/groups/list.tpl -->
         <!-- ELSE -->
         <div class="col-xs-12">
             <div class="alert alert-warning">

--- a/themes/nodebb-theme-persona/templates/groups/list.tpl
+++ b/themes/nodebb-theme-persona/templates/groups/list.tpl
@@ -34,10 +34,9 @@
 
     <h3>My Groups</h3>
     
-    <h1>TESTING: [[pages:{template.name}, {username}]]</h1>
     <div component="groups/container" class="row" id="groups-list" data-nextstart={nextStart}>
         <!-- IF groups.length -->
-            <!-- IMPORT partials/groups/mylist.tpl -->
+            <!-- IMPORT partials/groups/list.tpl -->
         <!-- ELSE -->
         <div class="col-xs-12">
             <div class="alert alert-warning">

--- a/themes/nodebb-theme-persona/templates/partials/groups/mylist.tpl
+++ b/themes/nodebb-theme-persona/templates/partials/groups/mylist.tpl
@@ -1,0 +1,24 @@
+<div class="account"> 
+    {{{each groups}}}
+    <h3>hello?</h3>
+    <div class="col-lg-4 col-md-6 col-sm-12" component="groups/summary" data-slug="{groups.slug}">
+        <div class="panel panel-default">
+            <a href="{config.relative_path}/groups/{groups.slug}" class="panel-heading list-cover" style="<!-- IF groups.cover:thumb:url -->background-image: url({groups.cover:thumb:url});<!-- ENDIF groups.cover:thumb:url -->">
+                <h3 class="panel-title">{groups.displayName} <small>{groups.memberCount}</small></h3>
+            </a>
+            <div class="panel-body">
+                <ul class="members">
+                    {{{each groups.members}}}
+                    <li>
+                        <a href="{config.relative_path}/user/{groups.members.userslug}">{buildAvatar(groups.members, "sm", true)}</a>
+                    </li>
+                    {{{end}}}
+                    <!-- IF groups.truncated -->
+                    <li class="truncated"><i class="fa fa-ellipsis-h"></i></li>
+                    <!-- ENDIF groups.truncated -->
+                </ul>
+            </div>
+        </div>
+    </div>
+    {{{end}}}
+</div>


### PR DESCRIPTION
- Attempts to Fix #7 
- Successfully created subsections 'My Groups' and 'Other Groups' in Groups page visually
- Groups within the subsections, however, are not filtered yet as intended
- Made progress in finding where in frontend and backend this filtering should be done, but haven't been able to implement it correctly yet
- Pushed commented-out code to show the progress and attempts
- No formal testing required yet, just visual changes in tpl files (no backend changes yet)

- Linter testing is failing due to the new plugin (file .eslintrc from plugins/nodebb-plugin-dev-template/), though there are no problems compiling the code
<img width="523" alt="Screenshot 2024-02-13 at 8 47 03 PM" src="https://github.com/CMU-313/spring24-nodebb-caffiends/assets/92954533/92451805-1133-48e2-b40d-df059bca8136">

