### PR TITLE
Publicandprivate buttons

### DIFF
--- a/plugins/nodebb-plugin-dev-template/static/templates/composer.tpl
+++ b/plugins/nodebb-plugin-dev-template/static/templates/composer.tpl
@@ -50,25 +50,35 @@
 			<div class="display-scheduler pull-right hidden-sm hidden-xs{{{ if !canSchedule }}} hidden{{{ end }}}">
 				<i class="fa fa-clock-o"></i>
 			</div>
-			<div component="category-selector" class="btn-group bottom-sheet">
-				<button class="btn btn-default dropdown-toggle" data-toggle="dropdown"> Public</button>
-					<span component="category-selector-selected">
-						<span class="fa-stack">
+			<div>
+				<div component="category-selector" class="btn-group bottom-sheet">
+					<button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown"> Public</button>
+						<span component="category-selector-selected">
+							<span class="visible-sm-inline visible-md-inline visible-lg-inline">
+							</span>
+							
+							
 						</span>
 						
-					</span>
-					<span class="caret"></span>
-				</button>
+					</button>
+				</div>
 			</div>
+			<div>
+				<div component="category-selector" class="btn-group bottom-sheet">
+					<button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown"> Private</button>
+						<span component="category-selector-selected">
+							<span class="visible-sm-inline visible-md-inline visible-lg-inline">
+							</span>
+							
+							
+						</span>
+						
+					</button>
+				</div>
+			</div>
+		
 
 			<div class="btn-group pull-right action-bar hidden-sm hidden-xs">
-
-				
-
-
-
-
-				<button class="btn btn-primary composer-submit" data-action="post" tabindex="-8"><i class="fa fa-check"></i> Privacy</button>
 				<button class="btn btn-default composer-discard" data-action="discard" tabindex="-1"><i class="fa fa-times"></i> [[topic:composer.discard]]</button>
 
 				<ul class="dropdown-menu">{{{ each submitOptions }}}<li><a href="#" data-action="{./action}">{./text}</a></li>{{{ end }}}</ul>

--- a/plugins/nodebb-plugin-dev-template/static/templates/composer.tpl
+++ b/plugins/nodebb-plugin-dev-template/static/templates/composer.tpl
@@ -50,8 +50,25 @@
 			<div class="display-scheduler pull-right hidden-sm hidden-xs{{{ if !canSchedule }}} hidden{{{ end }}}">
 				<i class="fa fa-clock-o"></i>
 			</div>
+			<div component="category-selector" class="btn-group bottom-sheet">
+				<button class="btn btn-default dropdown-toggle" data-toggle="dropdown"> Public</button>
+					<span component="category-selector-selected">
+						<span class="fa-stack">
+						</span>
+						
+					</span>
+					<span class="caret"></span>
+				</button>
+			</div>
 
 			<div class="btn-group pull-right action-bar hidden-sm hidden-xs">
+
+				
+
+
+
+
+				<button class="btn btn-primary composer-submit" data-action="post" tabindex="-8"><i class="fa fa-check"></i> Privacy</button>
 				<button class="btn btn-default composer-discard" data-action="discard" tabindex="-1"><i class="fa fa-times"></i> [[topic:composer.discard]]</button>
 
 				<ul class="dropdown-menu">{{{ each submitOptions }}}<li><a href="#" data-action="{./action}">{./text}</a></li>{{{ end }}}</ul>


### PR DESCRIPTION
- I have made changes to the UI of the posts to include the options to toggle posts between public and private. #12  
- I have not completely implemented the buttons to produce full functionality in making posts private vs public; I have completed the button option which was the majority of my task for the week. 
- Made progress in identifying files that modify privileges for viewing posts between users and admin
- Made progress in identifying UI files for making UI adjustments
- Deleted hw1 testing file
- Visual testing utilized - yet to implement unit testing
- Linter testing is failing due to the new plugin (file .eslintrc from plugins/nodebb-plugin-dev-template/), though there are no problems compiling the code
<img width="1280" alt="Screenshot 2024-02-13 220145" src="https://github.com/CMU-313/spring24-nodebb-caffiends/assets/147002902/77903b32-2c2f-4d39-b28f-4a6a14d40b13">
